### PR TITLE
Update: Github button link in docs (Issue #7)

### DIFF
--- a/config.js
+++ b/config.js
@@ -12,7 +12,7 @@ const config = {
 		"helpUrl": "",
 		"tweetText": "",
 		"links": [
-			{ "text": "", "link": ""}
+			{ "text": "", "link": "" }
 		],
 		"search": {
 			"enabled": false,
@@ -25,10 +25,10 @@ const config = {
 	"sidebar": {
 		"forcedNavOrder": [
 			"/introduction",
-    		"/codeblock"
+			"/codeblock"
 		],
 		"links": [
-			{ "text": "Hasura", "link": "https://hasura.io"},
+			{ "text": "Hasura", "link": "https://hasura.io" },
 		],
 		"frontline": false,
 		"ignoreIndex": true,
@@ -37,7 +37,7 @@ const config = {
 		"title": "Gatsby Gitbook Boilerplate | Hasura",
 		"description": "Documentation built with mdx. Powering learn.hasura.io ",
 		"ogImage": null,
-		"docsLocation": "https://github.com/hasura/gatsby-gitbook-boilerplate/tree/master/content",
+		"docsLocation": "https://github.com/tpage99/a11yfirst",
 		"favicon": "https://graphql-engine-cdn.hasura.io/img/hasura_icon_black.svg"
 	},
 };

--- a/src/templates/docs.js
+++ b/src/templates/docs.js
@@ -108,7 +108,7 @@ export default class MDXRuntimeTest extends Component {
       }, [])
       .concat(navItems.items)
       .map(slug => {
-        if(slug) {
+        if (slug) {
           const { node } = allMdx.edges.find(
             ({ node }) => node.fields.slug === slug
           );
@@ -127,7 +127,7 @@ export default class MDXRuntimeTest extends Component {
     return (
       <Layout {...this.props}>
         <Helmet>
-          {metaTitle ? <title>{metaTitle}</title> : null }
+          {metaTitle ? <title>{metaTitle}</title> : null}
           {metaTitle ? <meta name="title" content={metaTitle} /> : null}
           {metaDescription ? <meta name="description" content={metaDescription} /> : null}
           {metaTitle ? <meta property="og:title" content={metaTitle} /> : null}
@@ -141,7 +141,7 @@ export default class MDXRuntimeTest extends Component {
             {mdx.fields.title}
           </h1>
           <Edit className={'mobileView'}>
-            <Link className={'gitBtn'} to={`${docsLocation}/${mdx.parent.relativePath}`}>
+            <Link className={'gitBtn'} to={`${docsLocation}`}>
               <img src={gitHub} alt={'Github logo'} /> Edit on GitHub
             </Link>
           </Edit>


### PR DESCRIPTION
**Overview:**
- Updated the "docsLocation" in the config.js file.
- Removed additional ${mdx.parent.relativePath} from the url in docs.js template. This ways users will be taken directly to the repo instead of a particular file. 

