### PR TITLE
Add WAVE to "Resources for Web Developers" Tools page

### DIFF
--- a/content/web-dev-resources/2-tools.md
+++ b/content/web-dev-resources/2-tools.md
@@ -25,6 +25,10 @@ Link: https://pattern-library.dequelabs.com
 
 ___  
 
+## WAVE  
+The Web Accessibility Evaluation Tool, or [WAVE](https://wave.webaim.org/extension), evaluates web content for accessibility issues for Chrome and Firefox browsers. The extension runs in the Chrome and Firefox browsers, ensuring private and secure accessibility reporting.
 
+Link: https://wave.webaim.org/extension/
+___  
 
 


### PR DESCRIPTION
Added [WAVE](https://wave.webaim.org/extension) as a Web Developer Tool Resource.

<img width="1271" alt="Screen Shot of WAVE added to the Web Developer Tools Resource page" src="https://user-images.githubusercontent.com/5023024/67149462-13449a00-f271-11e9-80cd-2ec8d3719b1b.png">


cc / #15 